### PR TITLE
Add jobTypes

### DIFF
--- a/submit_ts_step1.py
+++ b/submit_ts_step1.py
@@ -26,6 +26,8 @@ def submitTS():
   job = Job()
   job.setName('mandelbrot raw')
   job.setOutputSandbox( ['*log'] )
+  job.setType('MCSimulation')
+
   # this is so that the JOB_ID within the transformation can be evaluated on the fly in the job application, see below
   job.workflow.addParameter( Parameter( "JOB_ID", "000000", "string", "", "", True, False, "Initialize JOB_ID" ) )   
 

--- a/submit_ts_step2.py
+++ b/submit_ts_step2.py
@@ -24,6 +24,7 @@ def submitTS():
   job = Job()
   job.setName('merge mandelbrot')
   job.setOutputSandbox( ['*log'] )
+  job.setType('DataReprocessing')
 
   ## define the job workflow in 3 steps
   # job step1: setup software

--- a/submit_ts_step3.py
+++ b/submit_ts_step3.py
@@ -24,6 +24,7 @@ def submitTS():
   job = Job()
   job.setName('build mandelbrot')
   job.setOutputSandbox( ['*log'] )
+  job.setType('DataReprocessing')
 
   ## define the job workflow in 3 steps
   # job step1: setup software  


### PR DESCRIPTION
JobTypes are necessary for the proper treatment of the jobs in the inputdata executor for example.